### PR TITLE
Fixed array range bug

### DIFF
--- a/src/main/java/org/terasology/genome/util/CombinatoricsUtils.java
+++ b/src/main/java/org/terasology/genome/util/CombinatoricsUtils.java
@@ -36,7 +36,7 @@ public final class CombinatoricsUtils {
      * @return      An array of length <code>count</code> containing random indices with maximum value <code>max</code>
      */
     public static int[] getRandomPermutationIndicesWithoutRepetition(int count, int max, FastRandom rand) {
-        if (count > max) {
+        if (count > max + 1) {
             throw new IllegalArgumentException("Count cannot be larger than max");
         }
 

--- a/src/main/java/org/terasology/genome/util/CombinatoricsUtils.java
+++ b/src/main/java/org/terasology/genome/util/CombinatoricsUtils.java
@@ -42,7 +42,7 @@ public final class CombinatoricsUtils {
 
         // The slow way, but good enough for what we need for now
         List<Integer> lookup = new ArrayList<>();
-        for (int i = 0; i < max; i++) {
+        for (int i = 0; i <= max; i++) {
             lookup.add(i);
         }
 


### PR DESCRIPTION
Made a tiny range fix. This was caused due to the fact that indices are 0-indexed.
For example: In the case for just one element, `count=1` and `max=0` should not throw an error.