### PR TITLE
Modified breeding to work per trait 

### DIFF
--- a/src/main/java/org/terasology/genome/GenomeDefinition.java
+++ b/src/main/java/org/terasology/genome/GenomeDefinition.java
@@ -22,11 +22,12 @@ import org.terasology.genome.genomeMap.GenomeMap;
  * This class defines common properties of a certain organism type, namely the breeding algorithm and the genome map.
  */
 public class GenomeDefinition {
-    private BreedingAlgorithm breedingAlgorithm;
+    //change this to defaultBreedingAlgorithm
+    private BreedingAlgorithm defaultBreedingAlgorithm;
     private GenomeMap genomeMap;
 
-    public GenomeDefinition(BreedingAlgorithm breedingAlgorithm, GenomeMap genomeMap) {
-        this.breedingAlgorithm = breedingAlgorithm;
+    public GenomeDefinition(BreedingAlgorithm defaultBreedingAlgorithm, GenomeMap genomeMap) {
+        this.defaultBreedingAlgorithm = defaultBreedingAlgorithm;
         this.genomeMap = genomeMap;
     }
 
@@ -35,8 +36,10 @@ public class GenomeDefinition {
      *
      * @return The breeding algorithm used by this organism type
      */
-    public BreedingAlgorithm getBreedingAlgorithm() {
-        return breedingAlgorithm;
+
+    //change this to getDefaultBreedingAlgorithm
+    public BreedingAlgorithm getDefaultBreedingAlgorithm() {
+        return defaultBreedingAlgorithm;
     }
 
     /**

--- a/src/main/java/org/terasology/genome/GenomeDefinition.java
+++ b/src/main/java/org/terasology/genome/GenomeDefinition.java
@@ -19,10 +19,9 @@ import org.terasology.genome.breed.BreedingAlgorithm;
 import org.terasology.genome.genomeMap.GenomeMap;
 
 /**
- * This class defines common properties of a certain organism type, namely the breeding algorithm and the genome map.
+ * This class defines common properties of a certain organism type, namely the default breeding algorithm and the genome map.
  */
 public class GenomeDefinition {
-    //change this to defaultBreedingAlgorithm
     private BreedingAlgorithm defaultBreedingAlgorithm;
     private GenomeMap genomeMap;
 
@@ -32,12 +31,10 @@ public class GenomeDefinition {
     }
 
     /**
-     * Get the breeding algorithm used by this organism type.
+     * Get the default breeding algorithm used by this organism type.
      *
-     * @return The breeding algorithm used by this organism type
+     * @return The default breeding algorithm used by this organism type
      */
-
-    //change this to getDefaultBreedingAlgorithm
     public BreedingAlgorithm getDefaultBreedingAlgorithm() {
         return defaultBreedingAlgorithm;
     }

--- a/src/main/java/org/terasology/genome/genomeMap/GeneIndexGenomeMap.java
+++ b/src/main/java/org/terasology/genome/genomeMap/GeneIndexGenomeMap.java
@@ -27,7 +27,6 @@ import java.util.Map;
  * An implementation of GenomeMap.
  */
 public class GeneIndexGenomeMap implements GenomeMap {
-    //make this private after testing is done
     public Map<String, GenePropertyDefinition> propertyDefinitionMap = new LinkedHashMap<>();
 
     /**
@@ -36,6 +35,7 @@ public class GeneIndexGenomeMap implements GenomeMap {
      * @param propertyName The name of the property to be added
      * @param geneIndices The indices of the genes which the property depends
      * @param type The type of the property
+     * @param breedingAlgorithm The breeding algorithm of the property
      * @param geneStringTransformation A function to transform the gene into a property value
      * @param <T> The class used for the property value
      */
@@ -47,8 +47,14 @@ public class GeneIndexGenomeMap implements GenomeMap {
                 geneStringTransformation));
     }
 
-    public BreedingAlgorithm getPropertyBreedingAlgorithm(String property) {
-        return propertyDefinitionMap.get(property).breedingAlgorithm;
+    /**
+     * Get the breeding algorithm of the specified property.
+     *
+     * @param propertyName The name of the property to be added
+     */
+
+    public BreedingAlgorithm getPropertyBreedingAlgorithm(String propertyName) {
+        return propertyDefinitionMap.get(propertyName).breedingAlgorithm;
     }
 
 
@@ -77,8 +83,6 @@ public class GeneIndexGenomeMap implements GenomeMap {
         return (T) definition.transformation.apply(genesForProperty.toString());
     }
 
-    //add a type field here and maybe a breeding algorithm as well. this can be from getBreedingAlgorithm(String
-    // property, String genes) a new method
     public static final class GenePropertyDefinition<T> {
         public int[] geneIndices;
         public BreedingAlgorithm breedingAlgorithm;

--- a/src/main/java/org/terasology/genome/genomeMap/GeneIndexGenomeMap.java
+++ b/src/main/java/org/terasology/genome/genomeMap/GeneIndexGenomeMap.java
@@ -39,7 +39,6 @@ public class GeneIndexGenomeMap implements GenomeMap {
      * @param geneStringTransformation A function to transform the gene into a property value
      * @param <T> The class used for the property value
      */
-
     public <T> void addProperty(String propertyName, int[] geneIndices, Class<T> type,
                                 BreedingAlgorithm breedingAlgorithm,
                                 Function<String, T> geneStringTransformation) {
@@ -52,7 +51,6 @@ public class GeneIndexGenomeMap implements GenomeMap {
      *
      * @param propertyName The name of the property to be added
      */
-
     public BreedingAlgorithm getPropertyBreedingAlgorithm(String propertyName) {
         return propertyDefinitionMap.get(propertyName).breedingAlgorithm;
     }

--- a/src/main/java/org/terasology/genome/genomeMap/GeneIndexGenomeMap.java
+++ b/src/main/java/org/terasology/genome/genomeMap/GeneIndexGenomeMap.java
@@ -16,6 +16,9 @@
 package org.terasology.genome.genomeMap;
 
 import com.google.common.base.Function;
+import org.terasology.genome.breed.BreedingAlgorithm;
+import org.terasology.genome.breed.DiploidBreedingAlgorithm;
+import org.terasology.genome.breed.MonoploidBreedingAlgorithm;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,29 +27,38 @@ import java.util.Map;
  * An implementation of GenomeMap.
  */
 public class GeneIndexGenomeMap implements GenomeMap {
-    private Map<String, GenePropertyDefinition> propertyDefinitionMap = new HashMap<>();
+    //make this private after testing is done
+    public Map<String, GenePropertyDefinition> propertyDefinitionMap = new HashMap<>();
 
     /**
      * Add a new named property to the genome map.
      *
-     * @param propertyName             The name of the property to be added
-     * @param geneIndices              The indices of the genes which the property depends
-     * @param type                     The type of the property
+     * @param propertyName The name of the property to be added
+     * @param geneIndices The indices of the genes which the property depends
+     * @param type The type of the property
      * @param geneStringTransformation A function to transform the gene into a property value
-     * @param <T>                      The class used for the property value
+     * @param <T> The class used for the property value
      */
-    public <T> void addProperty(String propertyName, int[] geneIndices, Class<T> type, Function<String, T> geneStringTransformation) {
-        propertyDefinitionMap.put(propertyName, new GenePropertyDefinition<T>(geneIndices, type, geneStringTransformation));
+
+    public <T> void addProperty(String propertyName, int[] geneIndices, Class<T> type, BreedingAlgorithm breedingAlgorithm,
+                                Function<String, T> geneStringTransformation) {
+        propertyDefinitionMap.put(propertyName, new GenePropertyDefinition<T>(geneIndices, type, breedingAlgorithm,
+                geneStringTransformation));
     }
+
+    public BreedingAlgorithm getPropertyBreedingAlgorithm(String property) {
+        return propertyDefinitionMap.get(property).breedingAlgorithm;
+    }
+
 
     /**
      * Get the value of a named property for the specified genes of an organism.
      *
      * @param property Name of the property
-     * @param genes    Genes of the organism
-     * @param type     Type of the property
-     * @param <T>      The class used for the property value
-     * @return         The value of the property
+     * @param genes Genes of the organism
+     * @param type Type of the property
+     * @param <T> The class used for the property value
+     * @return The value of the property
      */
     @Override
     public <T> T getProperty(String property, String genes, Class<T> type) {
@@ -64,14 +76,19 @@ public class GeneIndexGenomeMap implements GenomeMap {
         return (T) definition.transformation.apply(genesForProperty.toString());
     }
 
+    //add a type field here and maybe a breeding algorithm as well. this can be from getBreedingAlgorithm(String
+    // property, String genes) a new method
     private static final class GenePropertyDefinition<T> {
         private int[] geneIndices;
+        private BreedingAlgorithm breedingAlgorithm;
         private Class<T> type;
         private Function<String, T> transformation;
 
-        private GenePropertyDefinition(int[] geneIndices, Class<T> type, Function<String, T> transformation) {
+        private GenePropertyDefinition(int[] geneIndices, Class<T> type, BreedingAlgorithm breedingAlgorithm,
+                                       Function<String, T> transformation) {
             this.geneIndices = geneIndices;
             this.type = type;
+            this.breedingAlgorithm = breedingAlgorithm;
             this.transformation = transformation;
         }
     }

--- a/src/main/java/org/terasology/genome/genomeMap/GeneIndexGenomeMap.java
+++ b/src/main/java/org/terasology/genome/genomeMap/GeneIndexGenomeMap.java
@@ -20,7 +20,7 @@ import org.terasology.genome.breed.BreedingAlgorithm;
 import org.terasology.genome.breed.DiploidBreedingAlgorithm;
 import org.terasology.genome.breed.MonoploidBreedingAlgorithm;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -28,7 +28,7 @@ import java.util.Map;
  */
 public class GeneIndexGenomeMap implements GenomeMap {
     //make this private after testing is done
-    public Map<String, GenePropertyDefinition> propertyDefinitionMap = new HashMap<>();
+    public Map<String, GenePropertyDefinition> propertyDefinitionMap = new LinkedHashMap<>();
 
     /**
      * Add a new named property to the genome map.
@@ -40,7 +40,8 @@ public class GeneIndexGenomeMap implements GenomeMap {
      * @param <T> The class used for the property value
      */
 
-    public <T> void addProperty(String propertyName, int[] geneIndices, Class<T> type, BreedingAlgorithm breedingAlgorithm,
+    public <T> void addProperty(String propertyName, int[] geneIndices, Class<T> type,
+                                BreedingAlgorithm breedingAlgorithm,
                                 Function<String, T> geneStringTransformation) {
         propertyDefinitionMap.put(propertyName, new GenePropertyDefinition<T>(geneIndices, type, breedingAlgorithm,
                 geneStringTransformation));
@@ -78,14 +79,14 @@ public class GeneIndexGenomeMap implements GenomeMap {
 
     //add a type field here and maybe a breeding algorithm as well. this can be from getBreedingAlgorithm(String
     // property, String genes) a new method
-    private static final class GenePropertyDefinition<T> {
-        private int[] geneIndices;
-        private BreedingAlgorithm breedingAlgorithm;
-        private Class<T> type;
-        private Function<String, T> transformation;
+    public static final class GenePropertyDefinition<T> {
+        public int[] geneIndices;
+        public BreedingAlgorithm breedingAlgorithm;
+        public Class<T> type;
+        public Function<String, T> transformation;
 
-        private GenePropertyDefinition(int[] geneIndices, Class<T> type, BreedingAlgorithm breedingAlgorithm,
-                                       Function<String, T> transformation) {
+        public GenePropertyDefinition(int[] geneIndices, Class<T> type, BreedingAlgorithm breedingAlgorithm,
+                                      Function<String, T> transformation) {
             this.geneIndices = geneIndices;
             this.type = type;
             this.breedingAlgorithm = breedingAlgorithm;

--- a/src/main/java/org/terasology/genome/genomeMap/SeedBasedGenomeMap.java
+++ b/src/main/java/org/terasology/genome/genomeMap/SeedBasedGenomeMap.java
@@ -28,7 +28,6 @@ import org.terasology.world.WorldProvider;
  */
 
 
-//have to still change breeding algo stuff here
 public class SeedBasedGenomeMap extends GeneIndexGenomeMap {
     private int mapSeed;
 
@@ -44,6 +43,7 @@ public class SeedBasedGenomeMap extends GeneIndexGenomeMap {
      * @param maxGeneIndex The maximum index of a gene that can affect the property
      * @param codeLength The maximum length of a gene sequence that can affect the property
      * @param type The type of the property
+     * @param breedingAlgorithm The breeding algorithm of the property
      * @param geneStringTransformation A function that transforms a gene into a property value
      * @param <T> The class used for the property
      */
@@ -69,6 +69,7 @@ public class SeedBasedGenomeMap extends GeneIndexGenomeMap {
      * @param propertyName The name of the property
      * @param codeLength The maximum length of a gene sequence that can affect the property
      * @param type The type of the property
+     * @param breedingAlgorithm The breeding algorithm of the property
      * @param geneStringTransformation A function that transforms a gene into a property value
      * @param <T> The class used for the property
      */

--- a/src/main/java/org/terasology/genome/genomeMap/SeedBasedGenomeMap.java
+++ b/src/main/java/org/terasology/genome/genomeMap/SeedBasedGenomeMap.java
@@ -16,6 +16,7 @@
 package org.terasology.genome.genomeMap;
 
 import com.google.common.base.Function;
+import org.terasology.genome.breed.BreedingAlgorithm;
 import org.terasology.genome.util.CombinatoricsUtils;
 import org.terasology.registry.CoreRegistry;
 import org.terasology.utilities.random.FastRandom;
@@ -25,6 +26,9 @@ import org.terasology.world.WorldProvider;
  * An extension of the GeneIndexGenomeMap class which adds seed based properties. Seed based properties are properties
  * which are calculated using a pseudo-random generator which uses the game's seed.
  */
+
+
+//have to still change breeding algo stuff here
 public class SeedBasedGenomeMap extends GeneIndexGenomeMap {
     private int mapSeed;
 
@@ -35,38 +39,43 @@ public class SeedBasedGenomeMap extends GeneIndexGenomeMap {
     /**
      * Add a new seed based (pseudo-random) property.
      *
-     * @param propertyName             The name of the property
-     * @param minGeneIndex             The minimum index of a which can affect the property
-     * @param maxGeneIndex             The maximum index of a gene that can affect the property
-     * @param codeLength               The maximum length of a gene sequence that can affect the property
-     * @param type                     The type of the property
+     * @param propertyName The name of the property
+     * @param minGeneIndex The minimum index of a which can affect the property
+     * @param maxGeneIndex The maximum index of a gene that can affect the property
+     * @param codeLength The maximum length of a gene sequence that can affect the property
+     * @param type The type of the property
      * @param geneStringTransformation A function that transforms a gene into a property value
-     * @param <T>                      The class used for the property
+     * @param <T> The class used for the property
      */
     public <T> void addSeedBasedProperty(String propertyName, int minGeneIndex, int maxGeneIndex, int codeLength,
-                                         Class<T> type, Function<String, T> geneStringTransformation) {
+                                         Class<T> type, BreedingAlgorithm breedingAlgorithm,
+                                         Function<String, T> geneStringTransformation) {
         if (maxGeneIndex < minGeneIndex || maxGeneIndex - minGeneIndex + 1 < codeLength) {
             throw new IllegalArgumentException("Incorrectly configured gene indices");
         }
         String seed = CoreRegistry.get(WorldProvider.class).getSeed();
         FastRandom rand = new FastRandom(seed.hashCode() + propertyName.hashCode() + mapSeed);
-        int[] selectedGeneIndices = CombinatoricsUtils.getRandomPermutationIndicesWithoutRepetition(codeLength, maxGeneIndex - minGeneIndex, rand);
+        int[] selectedGeneIndices = CombinatoricsUtils.getRandomPermutationIndicesWithoutRepetition(codeLength,
+                maxGeneIndex - minGeneIndex, rand);
         for (int i = 0; i < codeLength; i++) {
             selectedGeneIndices[i] += minGeneIndex;
         }
-        addProperty(propertyName, selectedGeneIndices, type, geneStringTransformation);
+        addProperty(propertyName, selectedGeneIndices, type, breedingAlgorithm, geneStringTransformation);
     }
 
     /**
      * Add a new seed based (pseudo-random) property.
      *
-     * @param propertyName             The name of the property
-     * @param codeLength               The maximum length of a gene sequence that can affect the property
-     * @param type                     The type of the property
+     * @param propertyName The name of the property
+     * @param codeLength The maximum length of a gene sequence that can affect the property
+     * @param type The type of the property
      * @param geneStringTransformation A function that transforms a gene into a property value
-     * @param <T>                      The class used for the property
+     * @param <T> The class used for the property
      */
-    public <T> void addSeedBasedProperty(String propertyName, int genomeLength, int codeLength, Class<T> type, Function<String, T> geneStringTransformation) {
-        addSeedBasedProperty(propertyName, 0, genomeLength, codeLength, type, geneStringTransformation);
+    public <T> void addSeedBasedProperty(String propertyName, int genomeLength, int codeLength, Class<T> type,
+                                         BreedingAlgorithm breedingAlgorithm,
+                                         Function<String, T> geneStringTransformation) {
+        addSeedBasedProperty(propertyName, 0, genomeLength, codeLength, type, breedingAlgorithm,
+                geneStringTransformation);
     }
 }

--- a/src/main/java/org/terasology/genome/genomeMap/SeedBasedGenomeMap.java
+++ b/src/main/java/org/terasology/genome/genomeMap/SeedBasedGenomeMap.java
@@ -39,7 +39,7 @@ public class SeedBasedGenomeMap extends GeneIndexGenomeMap {
      * Add a new seed based (pseudo-random) property.
      *
      * @param propertyName The name of the property
-     * @param minGeneIndex The minimum index of a which can affect the property
+     * @param minGeneIndex The minimum index of a gene that can affect the property
      * @param maxGeneIndex The maximum index of a gene that can affect the property
      * @param codeLength The maximum length of a gene sequence that can affect the property
      * @param type The type of the property

--- a/src/main/java/org/terasology/genome/system/SimpleGenomeManager.java
+++ b/src/main/java/org/terasology/genome/system/SimpleGenomeManager.java
@@ -82,15 +82,12 @@ public class SimpleGenomeManager extends BaseComponentSystem implements GenomeMa
      *         offspring
      */
 
-    //this method will need to be changed so traits are bred according to their own breeding algorithms, if nothing
-    // is specified then default can be used
     @Override
     public boolean applyBreeding(EntityRef organism1, EntityRef organism2, EntityRef offspring) {
-        int counter = 0;
+        int geneCounter = 0;
         int geneIndex = 0;
         int geneIndices[];
         String resultGenes = "";
-
         BreedingAlgorithm breedingAlgorithm;
 
         GenomeComponent genome1 = organism1.getComponent(GenomeComponent.class);
@@ -101,19 +98,15 @@ public class SimpleGenomeManager extends BaseComponentSystem implements GenomeMa
         }
 
         GenomeDefinition genomeDefinition = genomeRegistry.getGenomeDefinition(genome1.genomeId);
-
-        //here breed by getting breeding algorithm per gene, otherwise use defaultBreedingAlgorithm
-        //String resultGenes = genomeDefinition.getDefaultBreedingAlgorithm().produceCross(genome1.genes, genome2
-        //        .genes);
-
+        // here we may need to add something incase SeedBasedGenomeMap is used for the definition
         GeneIndexGenomeMap genomeMap1 = (GeneIndexGenomeMap) genomeDefinition.getGenomeMap();
         Map propertyDefinitionMap1 = new LinkedHashMap(genomeMap1.propertyDefinitionMap);
         ArrayList<GeneIndexGenomeMap.GenePropertyDefinition> genePropertyDefinitions =
                 new ArrayList(propertyDefinitionMap1.values());
 
         while (geneIndex != genome1.genes.length()) {
-            geneIndices = genePropertyDefinitions.get(counter).geneIndices;
-            breedingAlgorithm = genePropertyDefinitions.get(counter++).breedingAlgorithm;
+            geneIndices = genePropertyDefinitions.get(geneCounter).geneIndices;
+            breedingAlgorithm = genePropertyDefinitions.get(geneCounter++).breedingAlgorithm;
             if (geneIndex + geneIndices.length < genome1.genes.length()) {
                 resultGenes += "" + breedingAlgorithm.produceCross(genome1.genes.substring(geneIndex,
                         geneIndex + geneIndices.length), genome2.genes.substring(geneIndex,
@@ -125,7 +118,6 @@ public class SimpleGenomeManager extends BaseComponentSystem implements GenomeMa
             }
             geneIndex += geneIndices.length;
         }
-
 
         if (resultGenes == null) {
             return false;
@@ -175,7 +167,4 @@ public class SimpleGenomeManager extends BaseComponentSystem implements GenomeMa
 
         return genomeDefinition.getGenomeMap().getProperty(propertyName, genome.genes, type);
     }
-
-    //add a method here getGenomeBreedingAlgorithm. Add in the interface as well
-    //add getPropertyType method too
 }

--- a/src/main/java/org/terasology/genome/system/SimpleGenomeManager.java
+++ b/src/main/java/org/terasology/genome/system/SimpleGenomeManager.java
@@ -71,6 +71,8 @@ public class SimpleGenomeManager extends BaseComponentSystem implements GenomeMa
      * @param offspring The offspring
      * @return          Whether the two organisms were bred successfully and the resulting information was applied to the offspring
      */
+
+    //this method will need to be changed so traits are bred according to their own breeding algorithms, if nothing is specified then default can be used
     @Override
     public boolean applyBreeding(EntityRef organism1, EntityRef organism2, EntityRef offspring) {
         GenomeComponent genome1 = organism1.getComponent(GenomeComponent.class);
@@ -82,7 +84,8 @@ public class SimpleGenomeManager extends BaseComponentSystem implements GenomeMa
 
         GenomeDefinition genomeDefinition = genomeRegistry.getGenomeDefinition(genome1.genomeId);
 
-        String resultGenes = genomeDefinition.getBreedingAlgorithm().produceCross(genome1.genes, genome2.genes);
+        //here breed by getting breeding algorithm per gene, otherwise use defaultBreedingAlgorithm
+        String resultGenes = genomeDefinition.getDefaultBreedingAlgorithm().produceCross(genome1.genes, genome2.genes);
         if (resultGenes == null) {
             return false;
         }
@@ -107,7 +110,7 @@ public class SimpleGenomeManager extends BaseComponentSystem implements GenomeMa
             return false;
         }
 
-        return genomeDefinition.getBreedingAlgorithm().canCross(genome1.genes, genome2.genes);
+        return genomeDefinition.getDefaultBreedingAlgorithm().canCross(genome1.genes, genome2.genes);
     }
 
     /**
@@ -131,4 +134,7 @@ public class SimpleGenomeManager extends BaseComponentSystem implements GenomeMa
 
         return genomeDefinition.getGenomeMap().getProperty(propertyName, genome.genes, type);
     }
+
+    //add a method here getGenomeBreedingAlgorithm. Add in the interface as well
+    //add getPropertyType method too
 }

--- a/src/main/java/org/terasology/genome/system/SimpleGenomeManager.java
+++ b/src/main/java/org/terasology/genome/system/SimpleGenomeManager.java
@@ -112,7 +112,6 @@ public class SimpleGenomeManager extends BaseComponentSystem implements GenomeMa
                         geneIndex + geneIndices.length), genome2.genes.substring(geneIndex,
                         geneIndex + geneIndices.length));
             } else {
-                System.out.println(resultGenes);
                 resultGenes += "" + breedingAlgorithm.produceCross(genome1.genes.substring(geneIndex),
                         genome2.genes.substring(geneIndex));
             }

--- a/src/test/java/org/terasology/genome/GeneIndexGenomeMapTest.java
+++ b/src/test/java/org/terasology/genome/GeneIndexGenomeMapTest.java
@@ -28,9 +28,10 @@ import org.terasology.genome.genomeMap.GeneIndexGenomeMap;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import javax.annotation.Nullable;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 
 /**
  * Initial test setup based on working of Genomes before trait specific breeding algorithms were introduced

--- a/src/test/java/org/terasology/genome/GeneIndexGenomeMapTest.java
+++ b/src/test/java/org/terasology/genome/GeneIndexGenomeMapTest.java
@@ -16,19 +16,15 @@
 
 package org.terasology.genome;
 
+import org.junit.Before;
 import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Function;
-import org.terasology.entitySystem.systems.BaseComponentSystem;
-import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.genome.GenomeDefinition;
-import org.terasology.genome.GenomeRegistry;
 import org.terasology.genome.breed.BreedingAlgorithm;
 import org.terasology.genome.breed.MonoploidBreedingAlgorithm;
 import org.terasology.genome.breed.mutator.GeneMutator;
 import org.terasology.genome.breed.mutator.VocabularyGeneMutator;
 import org.terasology.genome.genomeMap.GeneIndexGenomeMap;
-import org.terasology.genome.genomeMap.SeedBasedGenomeMap;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
 
@@ -36,6 +32,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import javax.annotation.Nullable;
 
+/**
+ * Initial test setup based on working of Genomes before trait specific breeding algorithms were introduced
+ * this test is now obsolete/serves no purpose
+ */
 class GeneIndexGenomeMapTest {
     @In
     WorldProvider worldProvider;
@@ -64,7 +64,6 @@ class GeneIndexGenomeMapTest {
         GenomeDefinition genomeDefinition = new GenomeDefinition(breedingAlgorithm, genomeMap);
         GeneIndexGenomeMap genomeMap1 = (GeneIndexGenomeMap) genomeDefinition.getGenomeMap();
         assertEquals(genomeMap1.propertyDefinitionMap.toString(), genomeMap.propertyDefinitionMap.toString());
-        //System.out.println(genomeMap1.propertyDefinitionMap);
-        System.out.println(genomeMap1.getProperty("filling", "Aa", Integer.class));
+        assertEquals(genomeMap1.getProperty("filling", "Aa", Integer.class),5);
     }
 }

--- a/src/test/java/org/terasology/genome/GeneIndexGenomeMapTest.java
+++ b/src/test/java/org/terasology/genome/GeneIndexGenomeMapTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.genome;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Function;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.genome.GenomeDefinition;
+import org.terasology.genome.GenomeRegistry;
+import org.terasology.genome.breed.BreedingAlgorithm;
+import org.terasology.genome.breed.MonoploidBreedingAlgorithm;
+import org.terasology.genome.breed.mutator.GeneMutator;
+import org.terasology.genome.breed.mutator.VocabularyGeneMutator;
+import org.terasology.genome.genomeMap.GeneIndexGenomeMap;
+import org.terasology.genome.genomeMap.SeedBasedGenomeMap;
+import org.terasology.registry.In;
+import org.terasology.world.WorldProvider;
+
+import static org.junit.jupiter.api.Assertions.*;
+import javax.annotation.Nullable;
+
+class GeneIndexGenomeMapTest {
+    @In
+    WorldProvider worldProvider;
+
+    @In
+    GenomeRegistry genomeRegistry;
+
+    @Test
+    void testMethod() {
+        int genomeLength = 1;
+
+        //A=5, F=10, K=15
+        GeneMutator geneMutator = new VocabularyGeneMutator("ABCDEFGHIJK");
+        BreedingAlgorithm breedingAlgorithm = new MonoploidBreedingAlgorithm(0, 0.05f, geneMutator);
+        GeneIndexGenomeMap genomeMap = new GeneIndexGenomeMap();
+        int geneIndices[]={0};
+        genomeMap.addProperty("filling", geneIndices, Integer.class,breedingAlgorithm,
+                new Function<String, Integer>() {
+                    @Nullable
+                    @Override
+                    public Integer apply(@Nullable String input) {
+                        return (input.charAt(0) - 'A' + 5);
+                    }
+                });
+
+        GenomeDefinition genomeDefinition = new GenomeDefinition(breedingAlgorithm, genomeMap);
+        GeneIndexGenomeMap genomeMap1 = (GeneIndexGenomeMap) genomeDefinition.getGenomeMap();
+        assertEquals(genomeMap1.propertyDefinitionMap.toString(),genomeMap.propertyDefinitionMap.toString());
+        //System.out.println(genomeMap1.propertyDefinitionMap);
+        System.out.println(genomeMap1.getProperty("filling","Aa",Integer.class));
+    }
+}

--- a/src/test/java/org/terasology/genome/GeneIndexGenomeMapTest.java
+++ b/src/test/java/org/terasology/genome/GeneIndexGenomeMapTest.java
@@ -33,6 +33,7 @@ import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
 
 import static org.junit.jupiter.api.Assertions.*;
+
 import javax.annotation.Nullable;
 
 class GeneIndexGenomeMapTest {
@@ -50,8 +51,8 @@ class GeneIndexGenomeMapTest {
         GeneMutator geneMutator = new VocabularyGeneMutator("ABCDEFGHIJK");
         BreedingAlgorithm breedingAlgorithm = new MonoploidBreedingAlgorithm(0, 0.05f, geneMutator);
         GeneIndexGenomeMap genomeMap = new GeneIndexGenomeMap();
-        int geneIndices[]={0};
-        genomeMap.addProperty("filling", geneIndices, Integer.class,breedingAlgorithm,
+        int geneIndices[] = {0};
+        genomeMap.addProperty("filling", geneIndices, Integer.class, breedingAlgorithm,
                 new Function<String, Integer>() {
                     @Nullable
                     @Override
@@ -62,8 +63,8 @@ class GeneIndexGenomeMapTest {
 
         GenomeDefinition genomeDefinition = new GenomeDefinition(breedingAlgorithm, genomeMap);
         GeneIndexGenomeMap genomeMap1 = (GeneIndexGenomeMap) genomeDefinition.getGenomeMap();
-        assertEquals(genomeMap1.propertyDefinitionMap.toString(),genomeMap.propertyDefinitionMap.toString());
+        assertEquals(genomeMap1.propertyDefinitionMap.toString(), genomeMap.propertyDefinitionMap.toString());
         //System.out.println(genomeMap1.propertyDefinitionMap);
-        System.out.println(genomeMap1.getProperty("filling","Aa",Integer.class));
+        System.out.println(genomeMap1.getProperty("filling", "Aa", Integer.class));
     }
 }

--- a/src/test/java/org/terasology/genome/GenomeNewTest.java
+++ b/src/test/java/org/terasology/genome/GenomeNewTest.java
@@ -83,7 +83,7 @@ class GenomeNewTest {
         GenomeDefinition genomeDefinition = new GenomeDefinition(defaultBreedingAlgorithm, genomeMap);
         GeneIndexGenomeMap genomeMap1 = (GeneIndexGenomeMap) genomeDefinition.getGenomeMap();
         assertEquals(genomeMap1.propertyDefinitionMap.toString(), genomeMap.propertyDefinitionMap.toString());
-        assertEquals(genomeMap1.getProperty("filling","Aa",Integer.class),5);
+        assertEquals(genomeMap1.getProperty("filling", "Aa", Integer.class), 5);
     }
 
     @Test
@@ -104,7 +104,7 @@ class GenomeNewTest {
         assertEquals(genomeMap1.propertyDefinitionMap.toString(), genomeMap.propertyDefinitionMap.toString());
         assertEquals(genomeMap1.getProperty("height", "TT", Integer.class), 1);
         assertEquals(genomeMap1.getProperty("height", "tt", Integer.class), 0);
-        assertEquals(genomeMap1.getProperty("height", "Tt", Integer.class),1);
+        assertEquals(genomeMap1.getProperty("height", "Tt", Integer.class), 1);
     }
 
     @Test
@@ -114,17 +114,29 @@ class GenomeNewTest {
         int geneIndex = 0;
         BreedingAlgorithm breedingAlgorithm = defaultBreedingAlgorithm;
 
-        String g1 = "TT";
-        String g2 = "tt";
+        String g1 = "TTAF";
+        String g2 = "ttKK";
         GeneIndexGenomeMap genomeMap = new GeneIndexGenomeMap();
-        int geneIndices[] = new int[]{0, 1};
+        int geneDepends[] = new int[]{0, 1};
+        int geneIndices[];
+
         String propertyType = "discrete";
-        genomeMap.addProperty("height", geneIndices, Integer.class, defaultBreedingAlgorithm,
+        genomeMap.addProperty("height", geneDepends, Integer.class, defaultBreedingAlgorithm,
                 new Function<String, Integer>() {
                     @Nullable
                     @Override
                     public Integer apply(@Nullable String input) {
                         return (Character.isUpperCase(input.charAt(0)) ? 1 : 0);
+                    }
+                });
+
+        geneDepends = new int[]{2, 3};
+        genomeMap.addProperty("filling", geneDepends, Integer.class, defaultBreedingAlgorithm,
+                new Function<String, Integer>() {
+                    @Nullable
+                    @Override
+                    public Integer apply(@Nullable String input) {
+                        return (input.charAt(0) - 'A' + 5);
                     }
                 });
 
@@ -142,11 +154,10 @@ class GenomeNewTest {
                         geneIndex + geneIndices.length), g2.substring(geneIndex,
                         geneIndex + geneIndices.length));
             } else {
-                System.out.println(resultGenes);
                 resultGenes += "" + breedingAlgorithm.produceCross(g1.substring(geneIndex), g2.substring(geneIndex));
             }
             geneIndex += geneIndices.length;
         }
-        assertNotEquals(resultGenes,"");
+        assertNotEquals(resultGenes, "");
     }
 }

--- a/src/test/java/org/terasology/genome/GenomeNewTest.java
+++ b/src/test/java/org/terasology/genome/GenomeNewTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2020 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.genome;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.common.base.Function;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.genome.GenomeDefinition;
+import org.terasology.genome.GenomeRegistry;
+import org.terasology.genome.breed.BreedingAlgorithm;
+import org.terasology.genome.breed.MonoploidBreedingAlgorithm;
+import org.terasology.genome.breed.mutator.GeneMutator;
+import org.terasology.genome.breed.mutator.VocabularyGeneMutator;
+import org.terasology.genome.genomeMap.GeneIndexGenomeMap;
+import org.terasology.genome.genomeMap.SeedBasedGenomeMap;
+import org.terasology.registry.In;
+import org.terasology.world.WorldProvider;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import javax.annotation.Nullable;
+
+class GenomeNewTest {
+    @In
+    WorldProvider worldProvider;
+
+    @In
+    GenomeRegistry genomeRegistry;
+
+    @Test
+    void testContinuousTrait() {
+        int genomeLength = 1;
+        float mutationChance = 0.05f;
+        //A=5, F=10, K=15
+        GeneMutator geneMutator = new VocabularyGeneMutator("ABCDEFGHIJK");
+        BreedingAlgorithm breedingAlgorithm = new MonoploidBreedingAlgorithm(0, mutationChance, geneMutator);
+        GeneIndexGenomeMap genomeMap = new GeneIndexGenomeMap();
+        int geneIndices[] = new int[]{0};
+        //change the next line to include the type of trait
+        genomeMap.addProperty("filling", geneIndices, Integer.class, breedingAlgorithm,
+                new Function<String, Integer>() {
+                    @Nullable
+                    @Override
+                    public Integer apply(@Nullable String input) {
+                        return (input.charAt(0) - 'A' + 5);
+                    }
+                });
+
+        //change this to defaultBreedingAlgorithm
+        GenomeDefinition genomeDefinition = new GenomeDefinition(breedingAlgorithm, genomeMap);
+        GeneIndexGenomeMap genomeMap1 = (GeneIndexGenomeMap) genomeDefinition.getGenomeMap();
+        assertEquals(genomeMap1.propertyDefinitionMap.toString(), genomeMap.propertyDefinitionMap.toString());
+        //System.out.println(genomeMap1.propertyDefinitionMap);
+        System.out.println(genomeMap1.getProperty("filling", "Aa", Integer.class));
+        //also need to change everywhere to default breeding algorithm because the breeding algorithm will be defined
+        // per trait
+    }
+
+    @Test
+    void testDiscreteTrait() {
+        int genomeLength = 1;
+        float mutationChance = 0.05f;
+        //A=5, F=10, K=15
+        GeneMutator geneMutator = new VocabularyGeneMutator("ABCDEFGHIJK");
+        BreedingAlgorithm breedingAlgorithm = new MonoploidBreedingAlgorithm(0, mutationChance, geneMutator);
+        GeneIndexGenomeMap genomeMap = new GeneIndexGenomeMap();
+        int geneIndices[] = new int[]{0};
+        String propertyType = "discrete";
+        //change the next line to include the type of trait
+        genomeMap.addProperty("height", geneIndices, Integer.class, breedingAlgorithm,
+                new Function<String, Integer>() {
+                    @Nullable
+                    @Override
+                    public Integer apply(@Nullable String input) {
+                        return (Character.isUpperCase(input.charAt(0)) ? 1 : 0);
+                    }
+                });
+
+        //change this to defaultBreedingAlgorithm
+        GenomeDefinition genomeDefinition = new GenomeDefinition(breedingAlgorithm, genomeMap);
+        GeneIndexGenomeMap genomeMap1 = (GeneIndexGenomeMap) genomeDefinition.getGenomeMap();
+        assertEquals(genomeMap1.propertyDefinitionMap.toString(), genomeMap.propertyDefinitionMap.toString());
+        assertEquals(genomeMap1.getProperty("height", "TT", Integer.class), 1);
+        assertEquals(genomeMap1.getProperty("height", "tt", Integer.class), 0);
+        //System.out.println(genomeMap1.propertyDefinitionMap);
+        System.out.println(genomeMap1.getProperty("height", "tt", Integer.class));
+        //also need to change everywhere to default breeding algorithm because the breeding algorithm will be defined
+        // per trait
+    }
+}

--- a/src/test/java/org/terasology/genome/GenomeNewTest.java
+++ b/src/test/java/org/terasology/genome/GenomeNewTest.java
@@ -35,6 +35,10 @@ import org.terasology.world.WorldProvider;
 import static org.junit.jupiter.api.Assertions.*;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 class GenomeNewTest {
     @In
@@ -75,12 +79,14 @@ class GenomeNewTest {
     @Test
     void testDiscreteTrait() {
         int genomeLength = 1;
+        String g1 = "AF";
+        String g2 = "TA";
         float mutationChance = 0.05f;
         //A=5, F=10, K=15
         GeneMutator geneMutator = new VocabularyGeneMutator("ABCDEFGHIJK");
         BreedingAlgorithm breedingAlgorithm = new MonoploidBreedingAlgorithm(0, mutationChance, geneMutator);
         GeneIndexGenomeMap genomeMap = new GeneIndexGenomeMap();
-        int geneIndices[] = new int[]{0};
+        int geneIndices[] = new int[]{0, 1};
         String propertyType = "discrete";
         //change the next line to include the type of trait
         genomeMap.addProperty("height", geneIndices, Integer.class, breedingAlgorithm,
@@ -100,7 +106,29 @@ class GenomeNewTest {
         assertEquals(genomeMap1.getProperty("height", "tt", Integer.class), 0);
         //System.out.println(genomeMap1.propertyDefinitionMap);
         System.out.println(genomeMap1.getProperty("height", "tt", Integer.class));
-        //also need to change everywhere to default breeding algorithm because the breeding algorithm will be defined
-        // per trait
+        //System.out.println(genomeDefinition.getDefaultBreedingAlgorithm().produceCross(g1, g2));
+
+        int counter = 0;
+        String resultGenes = "";
+        int geneIndex = 0;
+
+        Map propertyDefinitionMap1 = new LinkedHashMap(genomeMap1.propertyDefinitionMap);
+        ArrayList<GeneIndexGenomeMap.GenePropertyDefinition> genePropertyDefinitions =
+                new ArrayList(propertyDefinitionMap1.values());
+        while (geneIndex != g1.length()) {
+            geneIndices = genePropertyDefinitions.get(counter).geneIndices;
+            breedingAlgorithm = genePropertyDefinitions.get(counter++).breedingAlgorithm;
+            if (geneIndex + geneIndices.length < g1.length()) {
+                resultGenes += "" + breedingAlgorithm.produceCross(g1.substring(geneIndex,
+                        geneIndex + geneIndices.length), g2.substring(geneIndex,
+                        geneIndex + geneIndices.length));
+            } else {
+                System.out.println(resultGenes);
+                resultGenes += "" + breedingAlgorithm.produceCross(g1.substring(geneIndex), g2.substring(geneIndex));
+            }
+            geneIndex += geneIndices.length;
+        }
+
+        System.out.println(resultGenes);
     }
 }

--- a/src/test/java/org/terasology/genome/GenomeNewTest.java
+++ b/src/test/java/org/terasology/genome/GenomeNewTest.java
@@ -34,7 +34,9 @@ import org.terasology.genome.genomeMap.SeedBasedGenomeMap;
 import org.terasology.registry.In;
 import org.terasology.world.WorldProvider;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -81,7 +83,7 @@ class GenomeNewTest {
         GenomeDefinition genomeDefinition = new GenomeDefinition(defaultBreedingAlgorithm, genomeMap);
         GeneIndexGenomeMap genomeMap1 = (GeneIndexGenomeMap) genomeDefinition.getGenomeMap();
         assertEquals(genomeMap1.propertyDefinitionMap.toString(), genomeMap.propertyDefinitionMap.toString());
-        System.out.println(genomeMap1.getProperty("filling", "Aa", Integer.class));
+        assertEquals(genomeMap1.getProperty("filling","Aa",Integer.class),5);
     }
 
     @Test
@@ -102,7 +104,7 @@ class GenomeNewTest {
         assertEquals(genomeMap1.propertyDefinitionMap.toString(), genomeMap.propertyDefinitionMap.toString());
         assertEquals(genomeMap1.getProperty("height", "TT", Integer.class), 1);
         assertEquals(genomeMap1.getProperty("height", "tt", Integer.class), 0);
-        System.out.println(genomeMap1.getProperty("height", "Tt", Integer.class));
+        assertEquals(genomeMap1.getProperty("height", "Tt", Integer.class),1);
     }
 
     @Test
@@ -145,6 +147,6 @@ class GenomeNewTest {
             }
             geneIndex += geneIndices.length;
         }
-        System.out.println(resultGenes);
+        assertNotEquals(resultGenes,"");
     }
 }


### PR DESCRIPTION
Modified the genomes system to allow registering breeding algorithms per trait and a default breeding algorithm for the entity which will be used incase a breeding algorithm is not specified per trait. Also changed the traits to be stored in a linked hash map rather than a hash map so they are stored sequentially to maintain order. 
Added tests to check the working of Genomes while making modifications. 

**To-do list :**
- [x] Code Cleanup (major)
- [x] More tests to check breeding of multiple traits for the same entity
