### PR TITLE
Added a null breeding algorithm overload to GeneIndexGenomeMap.setProperty 

### DIFF
--- a/src/main/java/org/terasology/genome/genomeMap/GeneIndexGenomeMap.java
+++ b/src/main/java/org/terasology/genome/genomeMap/GeneIndexGenomeMap.java
@@ -48,7 +48,7 @@ public class GeneIndexGenomeMap implements GenomeMap {
 
     public <T> void addProperty(String propertyName, int[] geneIndices, Class<T> type,
                                 Function<String, T> geneStringTransformation) {
-        addProperty(propertyName, geneIndices, type, geneStringTransformation);
+        addProperty(propertyName, geneIndices, type, null,geneStringTransformation);
     }
 
     /**


### PR DESCRIPTION
Added a null breeding algorithm overload to GeneIndexGenomeMap.setProperty as it was earlier calling itself. This should fix the error that Genomes was causing in NeoTTA, however I request that NeoTTA is tested before merging this PR. Other errors (most probably unrelated to Genomes) showed up while trying to run NeoTTA