### PR TITLE
modified canBreed() methods

### DIFF
--- a/src/main/java/org/terasology/genome/breed/ContinuousBreedingAlgorithm.java
+++ b/src/main/java/org/terasology/genome/breed/ContinuousBreedingAlgorithm.java
@@ -49,7 +49,7 @@ public class ContinuousBreedingAlgorithm implements BreedingAlgorithm {
             return false;
         }
 
-        return (genes1.compareToIgnoreCase(genes2)) == 0;
+         return (genes1.length()==genes2.length());
     }
 
     /**

--- a/src/main/java/org/terasology/genome/breed/DiscreteBreedingAlgorithm.java
+++ b/src/main/java/org/terasology/genome/breed/DiscreteBreedingAlgorithm.java
@@ -49,7 +49,7 @@ public class DiscreteBreedingAlgorithm implements BreedingAlgorithm {
             return false;
         }
 
-        return (genes1.compareToIgnoreCase(genes2)) == 0;
+         return (genes1.length()==genes2.length());
     }
 
     /**


### PR DESCRIPTION
Changed the canBreed() checks for Continuous and Discrete breeding algorithms as they were implemented incorrectly earlier. The check now uses a check for length rather than comparing the genes if they are equal as done previously
